### PR TITLE
Feature/117 better git watch docs

### DIFF
--- a/Dockerfile_workstation
+++ b/Dockerfile_workstation
@@ -20,7 +20,7 @@ RUN apt-get -y install git software-properties-common wget openssl ssh curl jq a
     groupadd -f -g ${USER_GROUP_ID} ${USER} && \
     useradd -g ${USER_GROUP_ID} -u ${USER_ID} -ms /bin/bash ${USER}
 
-ENV GO_VERSION 1.11.5
+ENV GO_VERSION 1.11.13
 
 RUN cd /home/${USER} && \
     mkdir -p /home/${USER}/go && \

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Developer utilities and tools (duat) Beta
 
-Version : <repo-version>0.11.6</repo-version>
+Version : <repo-version>0.12.0-feature-117-better-git-watch-docs-aaaagmrfobq</repo-version>
 
 duat is a set of tools useful for automating the bootstrapping of containerized workflows.  duat includes tools for working with software artifacts such as git branches and tags, semantic versioning, and docker image delivery.  duat is a work in progress experiment in using Go, and Kubernetes to manage portions of container centric software lifecycles, helping to remove proprietary tooling, scripting, and other DSLs typically used for building, releasing, and deploying software.
 
@@ -281,7 +281,7 @@ Templates also support functions from masterminds.github.io/sprig.  Please refer
 
 The primary use case for git-watch is to be able to build CI/CD docker images from git repositories when commits occur.  git-watch meets an unaddressed need for an ad-hoc git client that can produce CI/CD docker images that can then feed into container centric CI/CD pipelines, all hosted within a single node Kubernetes deployment.
 
-This document describes by example the git-watch tool using a combination of github, docker registries, and finally keel.sh for downstream CI.
+This document describes by example the git-watch tool using a combination of git, docker registries, and finally keel.sh for downstream CI.
 
 ### audience
 
@@ -464,7 +464,7 @@ Please review https://github.com/mgutz/logxi for more information on logging lev
 ### usage
 
 <pre><code>
-Usage of git-watch: [options] [arguments]      Git Commit watcher and trigger (git-watch)
+usage:  git-watch [options] [arguments]      Git Commit watcher and trigger (git-watch)       1910aaf935e3a53cf22de4ede292492b77164bdb      2019-07-18_13:01:01-0700
 
 Arguments:
 
@@ -479,10 +479,15 @@ Example of valid arguments include:
 
 Options:
 
+  -debug
+        Enables features useful for when doing step by step debugging such as delaying cleanup operations etc
   -github-token string
         A github token that can be used to access the repositories that will be watched
   -job-template string
-        The Kubernetes job specification stencil template file name that is run on a change being detected, env var GIT_HOME will be set to indicate the repo directory of the captured repository
+        The Kubernetes job specification stencil template file name that is run on a change being detected, env var GIT_HOME will be set to indicate the repo directory of
+the captured repository
+  -namespace string
+        The namespace that should be used for processing the bootstrap, potentially destructive cleanup might be used on this namespace
   -persistent-state-dir string
         Overrides the default directory used to store state information for the last known commit of the repositories being watched (default "/tmp/git-watcher")
   -v    When enabled will print internal logging for this tool

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Developer utilities and tools (duat) Beta
 
-Version : <repo-version>0.12.0-feature-117-better-git-watch-docs-aaaagmrfobq</repo-version>
+Version : <repo-version>0.12.0-feature-117-better-git-watch-docs-aaaagmrgfxe</repo-version>
 
 duat is a set of tools useful for automating the bootstrapping of containerized workflows.  duat includes tools for working with software artifacts such as git branches and tags, semantic versioning, and docker image delivery.  duat is a work in progress experiment in using Go, and Kubernetes to manage portions of container centric software lifecycles, helping to remove proprietary tooling, scripting, and other DSLs typically used for building, releasing, and deploying software.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Developer utilities and tools (duat) Beta
 
-Version : <repo-version>0.12.0-feature-117-better-git-watch-docs-aaaagmrgfxe</repo-version>
+Version : <repo-version>0.12.0-feature-117-better-git-watch-docs-aaaagmrgktw</repo-version>
 
 duat is a set of tools useful for automating the bootstrapping of containerized workflows.  duat includes tools for working with software artifacts such as git branches and tags, semantic versioning, and docker image delivery.  duat is a work in progress experiment in using Go, and Kubernetes to manage portions of container centric software lifecycles, helping to remove proprietary tooling, scripting, and other DSLs typically used for building, releasing, and deploying software.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Developer utilities and tools (duat) Beta
 
-Version : <repo-version>0.12.0-feature-117-better-git-watch-docs-aaaagmrgktw</repo-version>
+Version : <repo-version>0.12.0-feature-117-better-git-watch-docs-aaaagmupwkb</repo-version>
 
 duat is a set of tools useful for automating the bootstrapping of containerized workflows.  duat includes tools for working with software artifacts such as git branches and tags, semantic versioning, and docker image delivery.  duat is a work in progress experiment in using Go, and Kubernetes to manage portions of container centric software lifecycles, helping to remove proprietary tooling, scripting, and other DSLs typically used for building, releasing, and deploying software.
 
@@ -355,7 +355,7 @@ localhost:
         client:
           disabled: true
 $ export Registry=`cat ../../registry_local.yaml`
-$ git-watch -v --job-template ../../ci_containerize_local.yaml https://github.com/karlmutch/duat.git^feature/102_microk8s_registry
+$ git-watch -v --ignore-aws-errors --job-template ../../ci_containerize_local.yaml https://github.com/karlmutch/duat.git^feature/102_microk8s_registry
 16:05:42.953783 INF git-watch task update id: 3b8e99c8-aed8-40d0-8ccd-82c8db391ff5 text: volume update namespace: gw-0-11-1-feature-102-microk8s-registry-aaaagjfuypo volume: 3b8e99c8-aed8-40d0-8ccd-82c8db391ff5 phase: (v1.PersistentVolumeClaimPhase) (len=5) "Bound"
 16:05:47.257452 INF git-watch task update id: 3b8e99c8-aed8-40d0-8ccd-82c8db391ff5 text: pod update phase: Pending id: 3b8e99c8-aed8-40d0-8ccd-82c8db391ff5 namespace: gw-0-11-1-feature-102-microk8s-registry-aaaagjfuypo
 16:05:48.160613 INF git-watch task update id: 3b8e99c8-aed8-40d0-8ccd-82c8db391ff5 text: pod update id: 3b8e99c8-aed8-40d0-8ccd-82c8db391ff5 namespace: gw-0-11-1-feature-102-microk8s-registry-aaaagjfuypo phase: Running

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Developer utilities and tools (duat) Beta
 
-Version : <repo-version>0.12.0-feature-117-better-git-watch-docs-aaaagmupwkb</repo-version>
+Version : <repo-version>0.12.0</repo-version>
 
 duat is a set of tools useful for automating the bootstrapping of containerized workflows.  duat includes tools for working with software artifacts such as git branches and tags, semantic versioning, and docker image delivery.  duat is a work in progress experiment in using Go, and Kubernetes to manage portions of container centric software lifecycles, helping to remove proprietary tooling, scripting, and other DSLs typically used for building, releasing, and deploying software.
 

--- a/ci_containerize_local.yaml
+++ b/ci_containerize_local.yaml
@@ -9,7 +9,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: makisu
-        image: gcr.io/makisu-project/makisu:v0.1.9
+        image: gcr.io/makisu-project/makisu:v0.1.10
         imagePullPolicy: IfNotPresent
         restartpolicy: Never
         args:

--- a/cmd/git-watch/git-watch.go
+++ b/cmd/git-watch/git-watch.go
@@ -1,13 +1,13 @@
 package main
 
-// This file contains the main function for a git cimmit watcher that upon a git
-// commit occuring will activate a kubernetes job based upon a template.  In this
+// This file contains the main function for a git commit watcher that upon a git
+// pushed commit occuring will activate a kubernetes job based upon a template.  In this
 // case this could be a Mikasu build job to allow a CI pipeline to be initiated.
 //
 // The rational behind triggering pipeline in this manner is that it provides a
 // minimal viable way of self hosting a quay.io service.  It cannot match this
 // service with things such as security scanning of resulting images triggered
-// by cimmits but will perform at least minimal self hosted docker builds within
+// by commits but will perform at least minimal self hosted docker builds within
 // a users self provisioned Kubernetes cluster.  Subsequent images from Mikasu
 // can then be pushed to a vanilla docker image registry where scans and the like
 // can be performed.
@@ -30,6 +30,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/google/uuid"
 	"github.com/jjeffery/kv"
 	"github.com/karlmutch/duat"
@@ -59,7 +60,7 @@ import (
 )
 
 var (
-	defStateDir = "/tmp/git-watcher"
+	defStateDir = os.ExpandEnv("/tmp/git-watcher-${USER}")
 	logger      = logxi.NewLogger(logxi.NewConcurrentWriter(colorable.NewColorableStderr()), "git-watch")
 
 	githubToken = flag.String("github-token", "", "A github token that can be used to access the repositories that will be watched")
@@ -67,7 +68,8 @@ var (
 
 	namespace   = flag.String("namespace", "", "The namespace that should be used for processing the bootstrap, potentially destructive cleanup might be used on this namespace")
 	jobTemplate = flag.String("job-template", "", "The Kubernetes job specification stencil template file name that is run on a change being detected, env var GIT_HOME will be set to indicate the repo directory of the captured repository")
-	stateDir    = flag.String("persistent-state-dir", defStateDir[:], "Overrides the default directory used to store state information for the last known commit of the repositories being watched")
+	stateDir    = flag.String("persistent-state-dir", os.ExpandEnv(defStateDir[:]), "Overrides the default directory used to store state information for the last known commit of the repositories being watched")
+	ignoreWarn  = flag.Bool("ignore-warn", false, "Treat template warnings as non-fatal")
 	debugMode   = flag.Bool("debug", false, "Enables features useful for when doing step by step debugging such as delaying cleanup operations etc")
 )
 
@@ -170,6 +172,7 @@ func generateStartMsg(md *duat.MetaData, msg *git.Change) (start *kubernetes.Tas
 		OverrideValues: map[string]string{
 			"ID":        start.ID,
 			"Namespace": start.Namespace,
+			"Dir":       start.Dir,
 			"Commit":    msg.Commit,
 			"URL":       msg.URL,
 		},
@@ -199,7 +202,9 @@ func generateStartMsg(md *duat.MetaData, msg *git.Change) (start *kubernetes.Tas
 					fmt.Fprintf(os.Stderr, "%v\n",
 						kv.Wrap(err).With("template", *jobTemplate, "stack", stack.Trace().TrimRuntime()).With("version", version.GitHash))
 				}
-				os.Exit(-1)
+				if !*ignoreWarn {
+					os.Exit(-1)
+				}
 			}
 			for _, err := range warnings {
 				logger.Warn(err.Error())
@@ -304,16 +309,17 @@ func main() {
 
 	// If the stateDir was defaulted then create it if it does not exist otherwise
 	// if the user specified a value then that directory must actually exist
-	if *stateDir == defStateDir {
-		os.MkdirAll(*stateDir, 0700)
+	workingDir := os.ExpandEnv(*stateDir)
+	if workingDir == defStateDir {
+		os.MkdirAll(workingDir, 0700)
 	}
-	if _, errGo := os.Stat(*stateDir); errGo != nil && !os.IsNotExist(errGo) {
+	if _, errGo := os.Stat(workingDir); errGo != nil && !os.IsNotExist(errGo) {
 		fmt.Fprintf(os.Stderr, "%v\n",
 			kv.NewError("the state presistence directory must already exist").With("dir", *stateDir, "stack", stack.Trace().TrimRuntime()).With("version", version.GitHash))
 		os.Exit(-1)
 	}
 
-	watcher, err := git.NewGitWatcher(ctx, *stateDir, reportC)
+	watcher, err := git.NewGitWatcher(ctx, workingDir, reportC)
 	if err != nil {
 		logger.Info(err.Error())
 	}
@@ -378,6 +384,8 @@ func main() {
 				taskTracking.Lock()
 				taskTracking.tasks[start.ID] = start
 				taskTracking.Unlock()
+
+				spew.Dump(start)
 
 				taskTriggerC <- start
 			}

--- a/cmd/git-watch/git-watch.go
+++ b/cmd/git-watch/git-watch.go
@@ -66,11 +66,12 @@ var (
 	githubToken = flag.String("github-token", "", "A github token that can be used to access the repositories that will be watched")
 	verbose     = flag.Bool("v", false, "When enabled will print internal logging for this tool")
 
-	namespace   = flag.String("namespace", "", "The namespace that should be used for processing the bootstrap, potentially destructive cleanup might be used on this namespace")
-	jobTemplate = flag.String("job-template", "", "The Kubernetes job specification stencil template file name that is run on a change being detected, env var GIT_HOME will be set to indicate the repo directory of the captured repository")
-	stateDir    = flag.String("persistent-state-dir", os.ExpandEnv(defStateDir[:]), "Overrides the default directory used to store state information for the last known commit of the repositories being watched")
-	ignoreWarn  = flag.Bool("ignore-warn", false, "Treat template warnings as non-fatal")
-	debugMode   = flag.Bool("debug", false, "Enables features useful for when doing step by step debugging such as delaying cleanup operations etc")
+	namespace    = flag.String("namespace", "", "The namespace that should be used for processing the bootstrap, potentially destructive cleanup might be used on this namespace")
+	jobTemplate  = flag.String("job-template", "", "The Kubernetes job specification stencil template file name that is run on a change being detected, env var GIT_HOME will be set to indicate the repo directory of the captured repository")
+	stateDir     = flag.String("persistent-state-dir", os.ExpandEnv(defStateDir[:]), "Overrides the default directory used to store state information for the last known commit of the repositories being watched")
+	ignoreWarn   = flag.Bool("ignore-warn", false, "Treat template warnings as non-fatal")
+	debugMode    = flag.Bool("debug", false, "Enables features useful for when doing step by step debugging such as delaying cleanup operations etc")
+	awsErrIgnore = flag.Bool("ignore-aws-errors", false, "Used to manage whether AWS access and configuration not being present is treated as a fatal error")
 )
 
 // Usage will print the options and help screen when the flag package sees the help option
@@ -176,6 +177,7 @@ func generateStartMsg(md *duat.MetaData, msg *git.Change) (start *kubernetes.Tas
 			"Commit":    msg.Commit,
 			"URL":       msg.URL,
 		},
+		IgnoreAWSErrors: *awsErrIgnore,
 	}
 
 	microK8s := &kubernetes.MicroK8s{}

--- a/go.go
+++ b/go.go
@@ -449,6 +449,7 @@ func (md *MetaData) GoCompile(env map[string]string, tags []string, opts []strin
 	if ldPath, hasLdPath := os.LookupEnv("LD_LIBRARY_PATH"); hasLdPath {
 		buildEnv = append(buildEnv, fmt.Sprintf("LD_LIBRARY_PATH=%s", ldPath))
 	}
+	fmt.Println(os.Environ())
 	for k, v := range env {
 		buildEnv = append(buildEnv, fmt.Sprintf("%s='%s'", k, v))
 		switch k {
@@ -502,7 +503,7 @@ func (md *MetaData) GoTest(env map[string]string, tags []string, opts []string) 
 	if ldPath, hasLdPath := os.LookupEnv("LD_LIBRARY_PATH"); hasLdPath {
 		buildEnv = append(buildEnv, fmt.Sprintf("LD_LIBRARY_PATH=%s", ldPath))
 	}
-
+	fmt.Println(os.Environ())
 	for k, v := range env {
 		buildEnv = append(buildEnv, fmt.Sprintf("%s='%s'", k, v))
 	}

--- a/go.go
+++ b/go.go
@@ -445,6 +445,10 @@ func (md *MetaData) GoCompile(env map[string]string, tags []string, opts []strin
 	}
 
 	buildEnv := []string{"GO_ENABLED=0"}
+	// If the LD_LIBRARY_PATH is present bring it into the build automatically
+	if ldPath, hasLdPath := os.LookupEnv("LD_LIBRARY_PATH"); hasLdPath {
+		buildEnv = append(buildEnv, fmt.Sprintf("LD_LIBRARY_PATH=%s", ldPath))
+	}
 	for k, v := range env {
 		buildEnv = append(buildEnv, fmt.Sprintf("%s='%s'", k, v))
 		switch k {
@@ -494,6 +498,11 @@ func (md *MetaData) GoTest(env map[string]string, tags []string, opts []string) 
 	ldFlags = append(ldFlags, fmt.Sprintf("-X github.com/karlmutch/duat/version.SemVer=\"%s\"", md.SemVer.String()))
 
 	buildEnv := []string{"GO_ENABLED=0"}
+	// If the LD_LIBRARY_PATH is present bring it into the build automatically
+	if ldPath, hasLdPath := os.LookupEnv("LD_LIBRARY_PATH"); hasLdPath {
+		buildEnv = append(buildEnv, fmt.Sprintf("LD_LIBRARY_PATH=%s", ldPath))
+	}
+
 	for k, v := range env {
 		buildEnv = append(buildEnv, fmt.Sprintf("%s='%s'", k, v))
 	}

--- a/go.go
+++ b/go.go
@@ -449,7 +449,7 @@ func (md *MetaData) GoCompile(env map[string]string, tags []string, opts []strin
 	if ldPath, hasLdPath := os.LookupEnv("LD_LIBRARY_PATH"); hasLdPath {
 		buildEnv = append(buildEnv, fmt.Sprintf("LD_LIBRARY_PATH=%s", ldPath))
 	}
-	fmt.Println(os.Environ())
+
 	for k, v := range env {
 		buildEnv = append(buildEnv, fmt.Sprintf("%s='%s'", k, v))
 		switch k {
@@ -503,7 +503,7 @@ func (md *MetaData) GoTest(env map[string]string, tags []string, opts []string) 
 	if ldPath, hasLdPath := os.LookupEnv("LD_LIBRARY_PATH"); hasLdPath {
 		buildEnv = append(buildEnv, fmt.Sprintf("LD_LIBRARY_PATH=%s", ldPath))
 	}
-	fmt.Println(os.Environ())
+
 	for k, v := range env {
 		buildEnv = append(buildEnv, fmt.Sprintf("%s='%s'", k, v))
 	}


### PR DESCRIPTION
Added git-watch docs
Added new --ignore-aws-errors.  This allows AWS errors to be explicitly masked rather than just having the treat all warnings as errors with templating.  Also enhances the template API to enable the same feature.
Bump Go compiler version.
Upgrade Makisu to 1.10
Improve LD_LIBRARY_PATH handling so that builds inherit this from their parent process